### PR TITLE
Allow two new parameters to be sent to comforter: mergeBase and targetBranch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ coverage/
 app/bower_components/
 .generated
 .vagrant
-uploads
 app-coverage-data/
 .tmp

--- a/api/apps.js
+++ b/api/apps.js
@@ -98,6 +98,8 @@ router.post('/:id/coverage', gitlabAuth, function (req, res) {
 					project: req.body.project,
 					commit: req.body.commit,
 					branch: req.body.branch,
+					mergeBase: req.body.mergeBase,
+					targetBranch: req.body.targetBranch,
 					projectName: req.body.name,
 					coverage: coverage,
 					hasDetails: req.files.zip != null && req.files.zip.length,

--- a/lib/build.js
+++ b/lib/build.js
@@ -40,15 +40,21 @@ module.exports = function (data) {
 		buildFailed(data);
 	})
 
-	// Get default branch
-	// for now, default branch against which coverage is tracked is always master
 	.then(function () {
-		return q('master');
-	})
+		var promise = q.reject();
+		if (data.mergeBase) {
+			promise = getLastKnownCoverageOfCommit(data.project, data.mergeBase, data.projectName);
+		}
 
-	// Get last known coverage of the branch
-	.then(function (branchName) {
-		return getLastKnownCoverageOfBranch(data.project, branchName, data.projectName);
+		return promise.catch(function () {
+			// Get default branch
+			return q(data.targetBranch || 'master')
+
+			// Get last known coverage of the branch
+			.then(function (branchName) {
+				return getLastKnownCoverageOfBranch(data.project, branchName, data.projectName);
+			});
+		})
 	})
 
 	// get the coverage diff
@@ -117,6 +123,10 @@ module.exports = function (data) {
 
 var getLastKnownCoverageOfBranch = function (projectId, branchName, projectName) {
 	return App.getCoverageForBranch(projectId, branchName, projectName);
+};
+
+var getLastKnownCoverageOfCommit = function (projectId, commitHash, projectName) {
+	return App.getCoverageForCommit(projectId, commitHash, projectName);
 };
 
 var compareCoverage = function (newCoverage, oldCoverage) {

--- a/models/app.js
+++ b/models/app.js
@@ -52,6 +52,16 @@ appSchema.statics.getCoverageForBranch = function (projectId, branchName, projec
 	return deferred.promise;
 };
 
+appSchema.statics.getCoverageForCommit = function (projectId, commitHash, projectName) {
+	var deferred = q.defer();
+	this.findOne({project_id: projectId.toString(), project_name: projectName}, function (err, app) {
+		if (err) { return deferred.reject(err); }
+		if (!app || !app.commits || !app.commits[commitHash]) { return deferred.reject(); }
+		return deferred.resolve(app.commits[commitHash].coverage);
+	});
+	return deferred.promise;
+};
+
 var App = mongoose.model('App', appSchema);
 
 module.exports = App;

--- a/test-project/.bowerrc
+++ b/test-project/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components"
+}

--- a/test-project/package.json
+++ b/test-project/package.json
@@ -6,7 +6,7 @@
   "scripts": {
 		"test": "grunt test-ci",
 		"bower": "bower install",
-		"comforter:main": "comforter-cli --path coverage/lcov/lcov.info --branch $CI_COMMIT_REF_NAME --commit $CI_COMMIT_SHA --project $CI_PROJECT_ID --apiKey $GITLAB_API_KEY --zip coverage/lcov/lcov-report/ --host https://comforterdev.localtunnel.me"
+		"comforter:main": "comforter-cli --path coverage/lcov/lcov.info --branch $CI_COMMIT_REF_NAME --commit $CI_COMMIT_SHA --merge-base $CI_COMMIT_BEFORE_SHA --target-branch $CI_MERGE_REQUEST_TARGET_BRANCH_NAME --project $CI_PROJECT_ID --apiKey $GITLAB_API_KEY --zip coverage/lcov/lcov-report/ --host https://comforterdev.localtunnel.me --name Resourcify"
   },
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "karma-ng-scenario": "^0.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
 		"load-grunt-tasks": "^0.6.0",
-		"comforter-cli": "0.3.4",
+		"comforter-cli": "0.4.4",
 		"bower": "1.8.2"
   }
 }

--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything in this folder
+*
+!.gitignore


### PR DESCRIPTION
Comforter uses master as the benchmark branch to compare the converage changes.
targetBranch allows you to specify the branch instead. If not included, it defaults to master
mergeBase allows you to specify a commit hash to use instead. If not include
    or coverage has no data for the commit, it defaults to targetBranch.

Note: this requires coverage-cli to be updated to a 4.4 version that passes along
    mergeBase and targetBranch