### PR TITLE
Improve coverage report page

### DIFF
--- a/app/modules/app/app.directive.js
+++ b/app/modules/app/app.directive.js
@@ -1,9 +1,10 @@
 'use strict';
 
-function appDirective(api, $parse) {
+function appDirective(api, $parse, gitlabHost) {
 	return {
 		templateUrl: 'modules/app/app.directive.tpl.html',
 		link: function ($scope, elem, attr) {
+			$scope.gitlabHost = gitlabHost;
 			api.getApp($parse(attr.appId)($scope), $parse(attr.projectName)($scope)).then(function (app) {
 				$scope.app = app;
 			});
@@ -12,4 +13,4 @@ function appDirective(api, $parse) {
 }
 
 angular.module('comforter.app')
-.directive('app', ['apiService', '$parse', appDirective]);
+.directive('app', ['apiService', '$parse', 'gitlabHost', appDirective]);

--- a/app/modules/app/app.directive.tpl.html
+++ b/app/modules/app/app.directive.tpl.html
@@ -8,8 +8,19 @@
 		<div class="commit-list" flex>
 			<md-card class="app" ng-repeat="commit in app.commitList | orderBy:'created_at':true" ng-class="{'highlight': commit.commit === $routeParams.commit}">
 				<md-card-title>
-					<md-card-title-text><span class="md-title {{commit.diff >= 0 ? 'good' : 'bad'}}">
-						This commit ({{commit.commit | limitTo:7}}) {{commit.diff >= 0 ? 'improves' : 'decreases'}} coverage by {{commit.diff | number:4}}%
+					<md-card-title-text ng-if="!commit.diff.comparedCommit"><span class="md-title {{commit.diff >= 0 ? 'good' : 'bad'}}">
+						This commit
+						(<a ng-href="{{gitlabHost}}/{{app.path_with_namespace}}/commit/{{commit.commit}}">#{{commit.commit | limitTo:7}}</a>)
+						{{commit.diff >= 0 ? 'improves' : 'decreases'}} coverage by
+						{{commit.diff | number:4}}%
+					</span></md-card-title-text>
+					<md-card-title-text ng-if="commit.diff.comparedCommit"><span class="md-title {{commit.diff.change >= 0 ? 'good' : 'bad'}}">
+						This commit
+						(<a ng-href="{{gitlabHost}}/{{app.path_with_namespace}}/commit/{{commit.commit}}">#{{commit.commit | limitTo:7}}</a>)
+						{{commit.diff.change >= 0 ? 'improves' : 'decreases'}} coverage by
+						{{commit.diff.change | number:4}}%
+						compared to <a ng-href="/coverage/apps/{{app.project_id}}/{{app.project_name}}/{{commit.diff.comparedBranch}}">{{commit.diff.comparedBranch}}</a>
+						(<a ng-href="{{gitlabHost}}/{{app.path_with_namespace}}/commit/{{commit.diff.comparedCommit}}">#{{commit.diff.comparedCommit | limitTo:7}}</a>)
 					</span></md-card-title-text>
 				</md-card-title>
 				<md-card-content>

--- a/app/modules/app/app.directive.tpl.html
+++ b/app/modules/app/app.directive.tpl.html
@@ -21,7 +21,7 @@
 					<md-button ng-if="commit.hasDetails" class="md-raised" target="_self" ng-href="/coverage/apps/{{app.project_id}}/{{app.project_name}}/{{commit.branchPath}}">
 						View Coverage Details
 					</md-button>
-					<md-button class="md-primary" target="_blank" ng-href="https://gitlab.goreact.com/{{app.path_with_namespace}}/commit/{{commit.commit}}">
+					<md-button class="md-primary" target="_blank" ng-href="{{gitlabHost}}/{{app.path_with_namespace}}/commit/{{commit.commit}}">
 						View this commit on GitLab
 					</md-button>
 				</md-card-content>

--- a/lib/build.js
+++ b/lib/build.js
@@ -46,11 +46,11 @@ module.exports = function (data) {
 
 	.then(function () {
 		return makeTruthyPromise(data.mergeBase)
-			.then(getLastKnownCoverageOfCommit.bind(null, data.project, data.projectName))
+			.then(getLastKnownCommitInfo.bind(null, data.project, data.projectName))
 		.catch(function () {
 			return makeTruthyPromise(data.mergeRequestIID)
 				.then(getMergeBaseFromMR.bind(null, data.project, data.token, data.tokenType))
-				.then(getLastKnownCoverageOfCommit.bind(null, data.project, data.projectName));
+				.then(getLastKnownCommitInfo.bind(null, data.project, data.projectName));
 		})
 		.catch(function () {
 			return makeTruthyPromise(data.targetBranch)
@@ -60,34 +60,31 @@ module.exports = function (data) {
 				})
 				.catch(gitlabHelper.getDefaultBranch.bind(gitlabHelper, data.project, data.token, data.tokenType))
 				.catch(q.resolve('master'))
-				.then(getLastKnownCoverageOfBranch.bind(null, data.project, data.projectName));
+				.then(getLastKnownBranchInfo.bind(null, data.project, data.projectName));
 		});
 	})
 
 	// get the coverage diff
-	.then(function (oldCoverage) {
-		return compareCoverage(data.coverage, oldCoverage);
+	.then(function (oldInfo) {
+		return compareCoverage(data, oldInfo);
 	})
 
 	// Send success status with target_url path to coverage
-	.then(function (diffData) {
-
-		var diff = diffData.diff;
-		var allowLower = diffData.allowLower;
+	.then(function (diff) {
 
 		// coverage drop
 		var description, state;
-		if (diff < 0) {
-			description = 'Coverage was decreased by ' + (diff * -1) + '%';
+		if (diff.change < 0) {
+			description = 'Coverage was decreased by ' + (diff.change * -1) + '%';
 
-			if (allowLower) {
+			if (diff.allowLower) {
 				state = gitlabHelper.states.SUCCESS;
 			} else {
 				state = gitlabHelper.states.FAILED;
 			}
 
 		} else {
-			description = 'Coverage is increased by ' + diff + '%';
+			description = 'Coverage is increased by ' + diff.change + '%';
 			state = gitlabHelper.states.SUCCESS;
 		}
 
@@ -128,12 +125,12 @@ module.exports = function (data) {
 	});
 };
 
-var getLastKnownCoverageOfBranch = function (projectId, projectName, branchName) {
-	return App.getCoverageForBranch(projectId, branchName, projectName);
+var getLastKnownBranchInfo = function (projectId, projectName, branchName) {
+	return App.getInfoForBranch(projectId, branchName, projectName);
 };
 
-var getLastKnownCoverageOfCommit = function (projectId, projectName, commitHash) {
-	return App.getCoverageForCommit(projectId, commitHash, projectName);
+var getLastKnownCommitInfo = function (projectId, projectName, commitHash) {
+	return App.getInfoForCommit(projectId, commitHash, projectName);
 };
 
 var getMergeBaseFromMR = function (projectId, token, tokenType, mergeRequestIID) {
@@ -150,27 +147,29 @@ var getTargetBranchFromMR = function (projectId, token, tokenType, mergeRequestI
 		});
 };
 
-var compareCoverage = function (newCoverage, oldCoverage) {
-	var deferred = q.defer();
-
-	// If totaLines of newCoverage is above old, just naive compare
-	if (oldCoverage.totalLines) {
-		if (newCoverage.totalLines < oldCoverage.totalLines && (oldCoverage.totalLines - oldCoverage.totalCovered >= newCoverage.totalLines - newCoverage.totalCovered)) {
-			deferred.resolve({
-				diff: newCoverage.percent - oldCoverage.percent,
-				allowLower: true
-			});
-		} else {
-			deferred.resolve({
-				diff: newCoverage.percent - oldCoverage.percent
-			});
+var upgradeOldCoverageIfNeeded = function (coverage) {
+	if (typeof coverage === 'number') {
+		return {
+			percent: coverage,
+			totalLines: 0,
+			totalCovered: 0
 		}
-
-	} else {
-		deferred.resolve({diff: newCoverage.percent - oldCoverage});
 	}
+	return coverage;
+};
 
-	return deferred.promise;
+var compareCoverage = function (newInfo, oldInfo) {
+	oldInfo.coverage = upgradeOldCoverageIfNeeded(oldInfo.coverage);
+	return {
+		change: newInfo.coverage.percent - oldInfo.coverage.percent,
+		comparedBranch: oldInfo.branch,
+		comparedCommit: oldInfo.commit,
+		allowLower:
+			newInfo.coverage.totalLines < oldInfo.coverage.totalLines && (
+			oldInfo.coverage.totalLines - oldInfo.coverage.totalCovered >=
+			newInfo.coverage.totalLines - newInfo.coverage.totalCovered
+		)
+	};
 };
 
 var saveCommit = function (token, tokenType, commit) {

--- a/models/app.js
+++ b/models/app.js
@@ -34,7 +34,7 @@ appSchema.pre('save', function (next) {
 });
 
 // Get coverage for a branch
-appSchema.statics.getCoverageForBranch = function (projectId, branchName, projectName) {
+appSchema.statics.getInfoForBranch = function (projectId, branchName, projectName) {
 	var deferred = q.defer();
 	this.findOne({project_id: projectId.toString(), project_name: projectName}, function (err, app) {
 		if (err) { return deferred.reject(err); }
@@ -47,17 +47,17 @@ appSchema.statics.getCoverageForBranch = function (projectId, branchName, projec
 			return first.created_at > second.created_at ? -1 : 1;
 		});
 		if (!matches.length) { return deferred.resolve(0); }
-		return deferred.resolve(matches[0].coverage);
+		return deferred.resolve(matches[0]);
 	});
 	return deferred.promise;
 };
 
-appSchema.statics.getCoverageForCommit = function (projectId, commitHash, projectName) {
+appSchema.statics.getInfoForCommit = function (projectId, commitHash, projectName) {
 	var deferred = q.defer();
 	this.findOne({project_id: projectId.toString(), project_name: projectName}, function (err, app) {
 		if (err) { return deferred.reject(err); }
 		if (!app || !app.commits || !app.commits[commitHash]) { return deferred.reject(); }
-		return deferred.resolve(app.commits[commitHash].coverage);
+		return deferred.resolve(app.commits[commitHash]);
 	});
 	return deferred.promise;
 };


### PR DESCRIPTION
Makes the page use the gitlab host variable and tracks additional data. The title text now looks like:

>This commit ([#e0f81dc](gitlabHost/app.path_with_namespace/commit/commit.commit)) improves coverage by 0.0000% compared to [develop](/coverage/apps/app.project_id/app.project_name/commit.diff.comparedBranch) ([#02e6605](gitlabHost/app.path_with_namespace/commit/commit.diff.comparedCommit))

If showing and older coverage that doesn't have the compared branch/commit info, it looks like the previous version, but the commit has been changed to a hyperlink:

>This commit ([#e0f81dc](gitlabHost/app.path_with_namespace/commit/commit.commit)) improves coverage by 0.0000%